### PR TITLE
update dependency psr/log

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^7.2|^8.0",
         "react/http": "^1.2",
-        "psr/log": "^1.1"
+        "psr/log": "^1.1 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "monolog/monolog": "^2.2",


### PR DESCRIPTION
When I try to install the package, it say

```
  Problem 1
    - team-reflex/discord-php[v6.0.0-RC4, ..., v6.0.2] require discord-php/http ^8 -> satisfiable by discord-php/http[v8.0.0, ..., v8.x-dev].
    - discord-php/http[v8.0.0, ..., v8.x-dev] require psr/log ^1.1 -> found psr/log[1.1.0, ..., 1.1.4] but it conflicts with your root composer.json require (2).
    - Root composer.json requires team-reflex/discord-php ^6.0 -> satisfiable by team-reflex/discord-php[v6.0.0-RC4, v6.0.0, v6.0.1, v6.0.2].

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.
```