### PR TITLE
Add Get Current User Guild Member Endpoint

### DIFF
--- a/src/Discord/Endpoint.php
+++ b/src/Discord/Endpoint.php
@@ -178,6 +178,8 @@ class Endpoint
     public const USER_CURRENT_GUILDS = self::USER_CURRENT.'/guilds';
     // DELETE
     public const USER_CURRENT_GUILD = self::USER_CURRENT.'/guilds/:guild_id';
+    // GET
+    public const USER_CURRENT_MEMBER = self::USER_CURRENT.'/guilds/:guild_id/member';
     // GET, POST
     public const USER_CURRENT_CHANNELS = self::USER_CURRENT.'/channels';
     // GET


### PR DESCRIPTION
for OAuth2 with `guild.members.read` scope

https://github.com/discord/discord-api-docs/pull/4204

Not appear in [the current documentation](https://discord.com/developers/docs/resources/user) yet