### PR TITLE
Fix deferred reject

### DIFF
--- a/src/Discord/Http.php
+++ b/src/Discord/Http.php
@@ -37,7 +37,7 @@ class Http
      *
      * @var string
      */
-    public const VERSION = 'v9.0.0';
+    public const VERSION = 'v9.0.10';
 
     /**
      * Current Discord HTTP API version.

--- a/src/Discord/Http.php
+++ b/src/Discord/Http.php
@@ -358,9 +358,10 @@ class Http
                 $deferred->resolve($response);
                 $request->getDeferred()->resolve($data);
             }
-        }, function (Exception $e) use ($request) {
+        }, function (Exception $e) use ($request, $deferred) {
             $this->logger->warning($request.' failed: '.$e->getMessage());
 
+            $deferred->reject($e);
             $request->getDeferred()->reject($e);
         });
 


### PR DESCRIPTION
This PR aims to correct the lack of deferred rejection, when a non-HTTP error occurs.

When the error does not occur during the request, but before it.

This behavior was causing a block in the request execution queue, perceived due to the incorrect behavior of the websocket reconnection attempts, causing a bot inertia state, see: [The bot shuts down on its own. #534](https://github.com/discord-php/DiscordPHP/issues/534)

As this package is the basis for all other requests, I am creating this PR as a draft, so that it can be validated.