### PR TITLE
docblock: small fix.

### DIFF
--- a/src/Discord/Endpoint.php
+++ b/src/Discord/Endpoint.php
@@ -370,7 +370,7 @@ class Endpoint
      * the newly created instance.
      *
      * @param  string   $endpoint
-     * @param  string[] ...$args
+     * @param  string[] $args
      * @return Endpoint
      */
     public static function bind(string $endpoint, ...$args)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/653569/161035739-a8f3cb79-495b-4a71-a28b-1e71dbd89fbf.png)

Tooltip isn't visible on screenshot, but it says `Expected parameter of type 'string[]', 'string' provided `