### PR TITLE
Update APPLICATION_CURRENT endpoint

### DIFF
--- a/src/Discord/Endpoint.php
+++ b/src/Discord/Endpoint.php
@@ -227,7 +227,7 @@ class Endpoint
     // GET, PUT
     public const USER_CURRENT_APPLICATION_ROLE_CONNECTION = self::USER_CURRENT.'/applications/:application_id/role-connection';
     // GET
-    public const APPLICATION_CURRENT = 'oauth2/applications/@me';
+    public const APPLICATION_CURRENT = 'applications/@me';
 
     // GET, PATCH, DELETE
     public const WEBHOOK = 'webhooks/:webhook_id';


### PR DESCRIPTION
Update the url of `APPLICATION_CURRENT` endpoint to get new data not available in the old one.

New data:
- `role_connections_verification_url`
- `approximate_guild_count`
<sub>(And more, but undocumented at the moment)</sub>

See: 
- https://github.com/discord/discord-api-docs/pull/5971