### PR TITLE
improve exception classes

### DIFF
--- a/src/Discord/Exceptions/BadRequestException.php
+++ b/src/Discord/Exceptions/BadRequestException.php
@@ -12,11 +12,11 @@
 namespace Discord\Http\Exceptions;
 
 /**
- * Thrown when you do not have permissions to do something.
+ * Thrown when a request to Discord's REST API returned ClientErrorResponse.
  *
- * @author David Cole <david.cole1340@gmail.com>
+ * @author SQKo
  */
-class NoPermissionsException extends RequestFailedException
+class BadRequestException extends RequestFailedException
 {
-    protected $code = 403;
+    protected $code = 400;
 }

--- a/src/Discord/Exceptions/InvalidTokenException.php
+++ b/src/Discord/Exceptions/InvalidTokenException.php
@@ -18,4 +18,5 @@ namespace Discord\Http\Exceptions;
  */
 class InvalidTokenException extends RequestFailedException
 {
+    protected $code = 401;
 }

--- a/src/Discord/Exceptions/MethodNotAllowedException.php
+++ b/src/Discord/Exceptions/MethodNotAllowedException.php
@@ -12,11 +12,11 @@
 namespace Discord\Http\Exceptions;
 
 /**
- * Thrown when you do not have permissions to do something.
+ * Thrown when a request to Discord's REST API method is invalid.
  *
- * @author David Cole <david.cole1340@gmail.com>
+ * @author SQKo
  */
-class NoPermissionsException extends RequestFailedException
+class MethodNotAllowedException extends RequestFailedException
 {
-    protected $code = 403;
+    protected $code = 405;
 }

--- a/src/Discord/Exceptions/NotFoundException.php
+++ b/src/Discord/Exceptions/NotFoundException.php
@@ -18,4 +18,5 @@ namespace Discord\Http\Exceptions;
  */
 class NotFoundException extends RequestFailedException
 {
+    protected $code = 404;
 }

--- a/src/Discord/Exceptions/RateLimitException.php
+++ b/src/Discord/Exceptions/RateLimitException.php
@@ -12,11 +12,12 @@
 namespace Discord\Http\Exceptions;
 
 /**
- * Thrown when you do not have permissions to do something.
+ * Thrown when a request to Discord's REST API got rate limited and the library
+ * does not know how to handle.
  *
- * @author David Cole <david.cole1340@gmail.com>
+ * @author SQKo
  */
-class NoPermissionsException extends RequestFailedException
+class RateLimitException extends RequestFailedException
 {
-    protected $code = 403;
+    protected $code = 429;
 }

--- a/src/Discord/Exceptions/RequestFailedException.php
+++ b/src/Discord/Exceptions/RequestFailedException.php
@@ -11,13 +11,13 @@
 
 namespace Discord\Http\Exceptions;
 
-use Exception;
+use RuntimeException;
 
 /**
  * Thrown when a request to Discord's REST API fails.
  *
  * @author David Cole <david.cole1340@gmail.com>
  */
-class RequestFailedException extends Exception
+class RequestFailedException extends RuntimeException
 {
 }


### PR DESCRIPTION
- Changed `RequestFailedException` to extends a `RuntimeException` instead of `Exception`
- Made 4xx exceptions to have default `$code` property (like usual, the code will be replaced with [actual Discord error codes](https://discord.com/developers/docs/topics/opcodes-and-status-codes#json-json-error-codes) if theres any)
- Added three 4xx exception classes for convenience (to complete as documented https://discord.com/developers/docs/topics/opcodes-and-status-codes#http-http-response-codes):
  - BadRequestException (400)
  - MethodNotAllowedException (405)
  - RateLimitException (429) when the library cannot delay the request automatically / cannot handle what to do
- Bumped to version 10.3.0