### PR TITLE
Add react/promise v2 to v3 transition helper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,9 @@
         }
     ],
     "autoload": {
+        "files": [
+            "src/Discord/PromiseHelpers/bootstrap.php"
+        ],
         "psr-4": {
             "Discord\\Http\\": "src/Discord",
             "Tests\\Discord\\Http\\": "tests/Discord"
@@ -19,7 +22,7 @@
         "php": "^7.4|^8.0",
         "react/http": "^1.2",
         "psr/log": "^1.1 || ^2.0 || ^3.0",
-        "react/promise": "^2.2"
+        "react/promise": "^2.8 || >=3.0 <=3.1"
     },
     "suggest": {
         "guzzlehttp/guzzle": "For alternative to ReactPHP/Http Browser"

--- a/src/Discord/DriverInterface.php
+++ b/src/Discord/DriverInterface.php
@@ -12,7 +12,7 @@
 namespace Discord\Http;
 
 use Psr\Http\Message\ResponseInterface;
-use React\Promise\ExtendedPromiseInterface;
+use React\Promise\PromiseInterface;
 
 /**
  * Interface for an HTTP driver.
@@ -28,7 +28,7 @@ interface DriverInterface
      *
      * @param Request $request
      *
-     * @return ExtendedPromiseInterface<ResponseInterface>
+     * @return \Discord\Http\PromiseHelpers\PromiseInterfacePolyFill<ResponseInterface>|\React\Promise\ExtendedPromiseInterface<ResponseInterface>
      */
-    public function runRequest(Request $request): ExtendedPromiseInterface;
+    public function runRequest(Request $request): PromiseInterface;
 }

--- a/src/Discord/Drivers/Guzzle.php
+++ b/src/Discord/Drivers/Guzzle.php
@@ -12,12 +12,12 @@
 namespace Discord\Http\Drivers;
 
 use Discord\Http\DriverInterface;
+use Discord\Http\PromiseHelpers\Deferred;
 use Discord\Http\Request;
 use GuzzleHttp\Client;
 use GuzzleHttp\RequestOptions;
 use React\EventLoop\LoopInterface;
-use React\Promise\Deferred;
-use React\Promise\ExtendedPromiseInterface;
+use React\Promise\PromiseInterface;
 
 /**
  * guzzlehttp/guzzle driver for Discord HTTP client. (still with React Promise).
@@ -55,7 +55,7 @@ class Guzzle implements DriverInterface
         $this->client = new Client($options);
     }
 
-    public function runRequest(Request $request): ExtendedPromiseInterface
+    public function runRequest(Request $request): PromiseInterface
     {
         // Create a React promise
         $deferred = new Deferred();

--- a/src/Discord/Drivers/React.php
+++ b/src/Discord/Drivers/React.php
@@ -12,10 +12,11 @@
 namespace Discord\Http\Drivers;
 
 use Discord\Http\DriverInterface;
+use Discord\Http\PromiseHelpers\PromiseInterfacePolyFill;
 use Discord\Http\Request;
 use React\EventLoop\LoopInterface;
 use React\Http\Browser;
-use React\Promise\ExtendedPromiseInterface;
+use React\Promise\PromiseInterface;
 use React\Socket\Connector;
 
 /**
@@ -54,12 +55,12 @@ class React implements DriverInterface
         $this->browser = $browser->withRejectErrorResponse(false);
     }
 
-    public function runRequest(Request $request): ExtendedPromiseInterface
+    public function runRequest(Request $request): PromiseInterface
     {
-        return $this->browser->{$request->getMethod()}(
+        return new PromiseInterfacePolyFill($this->browser->{$request->getMethod()}(
             $request->getUrl(),
             $request->getHeaders(),
             $request->getContent()
-        );
+        ));
     }
 }

--- a/src/Discord/PromiseHelpers/CancellablePromiseInterface.php
+++ b/src/Discord/PromiseHelpers/CancellablePromiseInterface.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ * This file is a part of the DiscordPHP-Http project.
+ *
+ * Copyright (c) 2021-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE file.
+ */
+
+ namespace Discord\Http\PromiseHelpers;
+
+ /**
+  * A transition helper from react/promise v2 to react/promise v3.
+  * Please do not use this polyfill class in place of real CancellablePromiseInterface.
+  *
+  * @see \React\Promise\CancellablePromiseInterface
+  *
+  * @internal Used internally for DiscordPHP v10
+  *
+  * @since 10.4.0
+  */
+interface CancellablePromiseInterface
+{
+    public function cancel();
+}

--- a/src/Discord/PromiseHelpers/Deferred.php
+++ b/src/Discord/PromiseHelpers/Deferred.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is a part of the DiscordPHP-Http project.
+ *
+ * Copyright (c) 2021-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE file.
+ */
+
+namespace Discord\Http\PromiseHelpers;
+
+use React\Promise\Deferred as ReactDeferred;
+use React\Promise\PromiseInterface;
+
+/**
+ * A transition helper from react/promise v2 to react/promise v3.
+ * Please do not use this polyfill class in place of real Deferred.
+ *
+ * @see \React\Promise\Deferred
+ * @see PromisorInterface
+ *
+ * @internal Used internally for DiscordPHP v10
+ *
+ * @since 10.4.0
+ */
+final class Deferred implements PromisorInterface
+{
+    /**
+     * The actual Promisor
+     */
+    public ReactDeferred $deferred;
+
+    /**
+     * Determine the installed package is Promise-v3
+     */
+    public static bool $isPromiseV3 = false;
+
+    /**
+     * @var PromiseInterfacePolyFill|PromiseInterfacePolyFill
+     */
+    private $promise;
+
+    /**
+     * @param callable|ReactDeferred $canceller Canceller callback or a Deferred to use
+     *
+     * @throws \InvalidArgumentException $canceller is not null or callable or a Deferred
+     */
+    public function __construct($canceller = null)
+    {
+        if ($canceller instanceof ReactDeferred) {
+            $this->deferred = $canceller;
+        } elseif (null === $canceller || is_callable($canceller)) {
+            $this->deferred = new ReactDeferred($canceller);
+        } else {
+            throw new \InvalidArgumentException('$canceller must be either null or callable or Deferred');
+        }
+    }
+
+    /**
+     * @return PromiseInterfacePolyFill|PromiseInterface|\React\Promise\ExtendedPromiseInterface
+     */
+    public function promise()
+    {
+        if (!static::$isPromiseV3) {
+            // Just use the same react/promise v2 promise
+            return $this->deferred->promise();
+        }
+
+        if (null === $this->promise) {
+            // Wrap with the polyfill if user installed react/promise v3
+            $this->promise = new PromiseInterfacePolyFill($this->deferred->promise());
+        }
+
+        return $this->promise;
+    }
+
+    /**
+     * @see React\Promise\Deferred::resolve()
+     *
+     * @return void
+     */
+    public function resolve($value = null)
+    {
+        $this->deferred->resolve($value);
+    }
+
+    /**
+     * @see React\Promise\Deferred::reject()
+     *
+     * @param \Throwable $reason required in Promise-v3, will be resolved if not a throwable
+     *
+     * @throws \InvalidArgumentException $reason is null & react/promise is v3
+     *
+     * @return void
+     */
+    public function reject($reason = null)
+    {
+        if (static::$isPromiseV3) {
+            if (null === $reason) {
+                $reason = new \InvalidArgumentException('reject($reason) must not be null');
+            } elseif (!($reason instanceof \Throwable)) {
+                return $this->deferred->resolve($reason);
+            }
+        }
+
+        $this->deferred->reject($reason);
+    }
+
+    /**
+     * Not supported
+     *
+     * @deprecated
+     */
+    public function notify($update = null)
+    {
+        if (method_exists($this->deferred, 'notify')) {
+            $this->deferred->notify($update);
+            return;
+        }
+
+        throw new \BadMethodCallException('notify() is not supported with this polyfill and react/promise v3');
+    }
+
+    /**
+     * Not supported
+     *
+     * @deprecated
+     */
+    public function progress($update = null)
+    {
+        if (method_exists($this->deferred, 'progress')) {
+            $this->deferred->progress($update);
+            return;
+        }
+
+        throw new \BadMethodCallException('progress() is not supported with this polyfill and react/promise v3');
+    }
+}

--- a/src/Discord/PromiseHelpers/ExtendedPromiseInterface.php
+++ b/src/Discord/PromiseHelpers/ExtendedPromiseInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is a part of the DiscordPHP-Http project.
+ *
+ * Copyright (c) 2021-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE file.
+ */
+
+namespace Discord\Http\PromiseHelpers;
+
+/**
+ * A transition helper from react/promise v2 to react/promise v3.
+ * Please do not use this polyfill class in place of real ExtendedPromiseInterface.
+ *
+ * @see \React\Promise\ExtendedPromiseInterface
+ *
+ * @internal Used internally for DiscordPHP v10
+ *
+ * @since 10.4.0
+ */
+interface ExtendedPromiseInterface
+{
+    public function done(callable $onFulfilled = null, callable $onRejected = null, callable $onProgress = null);
+
+    public function otherwise(callable $onRejected);
+
+    public function always(callable $onFulfilledOrRejected);
+
+    public function progress(callable $onProgress);
+}

--- a/src/Discord/PromiseHelpers/PromiseInterfacePolyfill.php
+++ b/src/Discord/PromiseHelpers/PromiseInterfacePolyfill.php
@@ -1,0 +1,183 @@
+<?php
+
+/*
+ * This file is a part of the DiscordPHP-Http project.
+ *
+ * Copyright (c) 2021-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE file.
+ */
+
+namespace Discord\Http\PromiseHelpers;
+
+use React\Promise\PromiseInterface;
+use function React\Promise\reject;
+
+/**
+ * A transition helper from react/promise v2 to react/promise v3.
+ * Please do not use this polyfill class in place of real PromiseInterface.
+ *
+ * @see \React\Promise\PromiseInterface
+ * @see ExtendedPromiseInterface
+ * @see CancellablePromiseInterface
+ *
+ * @internal Used internally for DiscordPHP v10
+ *
+ * @since 10.4.0
+ */
+final class PromiseInterfacePolyFill implements PromiseInterface, \React\Promise\ExtendedPromiseInterface, \React\Promise\CancellablePromiseInterface
+{
+    /**
+     * The actual Promise, must not be this class
+     */
+    public PromiseInterface $promise;
+
+    /**
+     * @param \React\Promise\Promise|\React\Promise\FulfilledPromise|\React\Promise\RejectedPromise $promise
+     *
+     * @throws \InvalidArgumentException This polyfill cannot accept the same polyfill class.
+     */
+    public function __construct(PromiseInterface $promise)
+    {
+        if ($promise instanceof self) {
+            throw new \InvalidArgumentException('Cannot use polyfill inside the polyfill class');
+        }
+
+        $this->promise = $promise;
+    }
+
+    /**
+     * Converts then() and wrap it with this polyfill class.
+     *
+     * @see React\Promise\PromiseInterface::then()
+     *
+     * @param callable|null $onFulfilled
+     * @param callable|null $onRejected
+     * @param callable|null $onProgress This argument must not be used anymore.
+     *
+     * @throws \InvalidArgumentException $onProgress is not null & react/promise is v3
+     *
+     * @return self|PromiseInterface
+     */
+    public function then(callable $onFulfilled = null, callable $onRejected = null, callable $onProgress = null): PromiseInterface
+    {
+        if (method_exists($this->promise, 'progress')) {
+            return new self($this->promise->then($onFulfilled, $onRejected, $onProgress));
+        }
+
+        if (null !== $onProgress) {
+            return reject(new \InvalidArgumentException('$onProgress is not supported with this polyfill'));
+        }
+
+        return new self($this->promise->then($onFulfilled, $onRejected));
+    }
+
+    /**
+     * Do not use this in v3, use then().
+     *
+     * @see React\Promise\ExtendedPromiseInterface::done() v2
+     *
+     * @param callable|null $onFulfilled
+     * @param callable|null $onRejected
+     * @param callable|null $onProgress This argument must not be used anymore.
+     *
+     * @throws \InvalidArgumentException $onProgress is not null & react/promise is v3
+     *
+     * @deprecated 10.4.0 If you see this, please change done() to then()
+     *
+     * @return void
+     */
+    public function done(callable $onFulfilled = null, callable $onRejected = null, callable $onProgress = null)
+    {
+        if (method_exists($this->promise, 'done')) {
+            $this->promise->done($onFulfilled, $onRejected, $onProgress);
+            return;
+        }
+
+        if (null !== $onProgress) {
+            throw new \InvalidArgumentException('$onProgress is not supported with this polyfill and react/promise v3');
+        }
+
+        $this->promise->then($onFulfilled, $onRejected);
+        return;
+    }
+
+    /**
+     * @see React\Promise\ExtendedPromiseInterface::otherwise() v2
+     *
+     * @deprecated Promise-v3 Use catch() instead.
+     */
+    public function otherwise(callable $onRejected): PromiseInterface
+    {
+        return $this->catch($onRejected);
+    }
+
+    /**
+     * @see React\Promise\ExtendedPromiseInterface::always() v2
+     *
+     * @deprecated Promise-v3 Use finally() instead.
+     */
+    public function always(callable $onFulfilledOrRejected): PromiseInterface
+    {
+        return $this->finally($onFulfilledOrRejected);
+    }
+
+    /**
+     * @see React\Promise\CancellablePromiseInterface::cancel() v2
+     * @see React\Promise\PromiseInterface::cancel() v3
+     *
+     * @return void
+     */
+    public function cancel(): void
+    {
+        $this->promise->cancel();
+        return;
+    }
+
+    /**
+     * Not supported
+     *
+     * @deprecated
+     */
+    public function progress(callable $onProgress)
+    {
+        if (method_exists($this->promise, 'progress')) {
+            return $this->promise->progress($onProgress);
+        }
+
+        return reject(new \BadMethodCallException('progress() is not supported with this polyfill and react/promise v3'));
+    }
+
+    /**
+     * @see React\Promise\PromiseInterface::catch() v3
+     * @see React\Promise\ExtendedPromiseInterface::otherwise() v2
+     *
+     * @param callable $onRejected
+     * @return PromiseInterface
+     */
+    public function catch(callable $onRejected): PromiseInterface
+    {
+        if (method_exists($this->promise, 'catch')) {
+            return $this->promise->catch($onRejected);
+        }
+
+        return $this->promise->then(null, $onRejected);
+    }
+
+    /**
+     * @see React\Promise\PromiseInterface::finally() v3
+     * @see React\Promise\ExtendedPromiseInterface::always() v2
+     *
+     * @param callable $onFulfilledOrRejected
+     * @return PromiseInterface
+     */
+    public function finally(callable $onFulfilledOrRejected): PromiseInterface
+    {
+        if (method_exists($this->promise, 'finally')) {
+            return $this->promise->finally($onFulfilledOrRejected);
+        }
+
+        return $this->promise->always($onFulfilledOrRejected);
+    }
+}

--- a/src/Discord/PromiseHelpers/PromisorInterface.php
+++ b/src/Discord/PromiseHelpers/PromisorInterface.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ * This file is a part of the DiscordPHP-Http project.
+ *
+ * Copyright (c) 2021-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE file.
+ */
+
+ namespace Discord\Http\PromiseHelpers;
+
+ /**
+  * A transition helper from react/promise v2 to react/promise v3.
+  * Please do not use this polyfill class in place of real PromisorInterface.
+  *
+  * @see \React\Promise\PromisorInterface
+  *
+  * @internal Used internally for DiscordPHP v10
+  *
+  * @since 10.4.0
+  */
+interface PromisorInterface
+{
+    public function promise();
+}

--- a/src/Discord/PromiseHelpers/bootstrap.php
+++ b/src/Discord/PromiseHelpers/bootstrap.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is a part of the DiscordPHP-Http project.
+ *
+ * Copyright (c) 2021-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE file.
+ */
+
+namespace Discord\Http\PromiseHelpers;
+
+/**
+ * Interface aliases for Promise-v2 to Promise-v3 backward compatibility.
+ *
+ * @since 10.4.0
+ */
+if (!interface_exists('\React\Promise\PromisorInterface')) {
+    Deferred::$isPromiseV3 = true;
+    class_alias(PromisorInterface::class, '\React\Promise\PromisorInterface');
+}
+if (!interface_exists('\React\Promise\ExtendedPromiseInterface')) {
+    class_alias(ExtendedPromiseInterface::class, '\React\Promise\ExtendedPromiseInterface');
+}
+if (!interface_exists('\React\Promise\CancellablePromiseInterface')) {
+    class_alias(CancellablePromiseInterface::class, '\React\Promise\CancellablePromiseInterface');
+}

--- a/src/Discord/Request.php
+++ b/src/Discord/Request.php
@@ -11,7 +11,7 @@
 
 namespace Discord\Http;
 
-use React\Promise\Deferred;
+use Discord\Http\PromiseHelpers\Deferred;
 
 /**
  * Represents an HTTP request.


### PR DESCRIPTION
This is helper class for transitioning react/promise v2 to react/promise v3. No, we do not need to make sudden breaking changes to force everyone replace done() and then() because it is difficult to determine whether the promise should be chained or ends there.

With this, users are not forced to go with v3, they can force their composer install to v2, and the polyfill will wraps it directly to the v2 codes.

BC Note: progress/onProgress is not supported (it was deprecated long ago in v2, so the requirement is now atleast v2.8)

However, our internal codes must be changed to the react/promise v3 styles, while using the provided helper class, instead of the react/promise v3 class directly.

Many things that still need to be adjusted such as the ratelimit promise rejection since the react/promise reject() requires the value to be a throwable now (currently, the wrapper will force non exceptions values as resolved).

It has been tested with very simple basic requests.

```php
$http->get('sticker-packs')->done(function () {
    echo 'GOT ALL STICKER PACK';
}, function ($e) {
    var_dump($e->code);
});

$http->get('sticker-packs/847199849233514549')->done(function ($res) { // this endpoint no longer accessible by bots
    var_dump('GOT WUMPUS STICKER PACK', $res);
});
```
Log for both promise v2 and promise v3
```
[2023-12-09T14:38:09.549068+00:00] logger-name.DEBUG: BUCKET getsticker-packs queued REQ GET sticker-packs [] []
[2023-12-09T14:38:09.582967+00:00] logger-name.DEBUG: BUCKET getsticker-packs/847199849233514549 queued REQ GET sticker-packs/847199849233514549 [] []
[2023-12-09T14:38:10.431113+00:00] logger-name.DEBUG: REQ GET sticker-packs successful [] []
[2023-12-09T14:38:10.431460+00:00] logger-name.DEBUG: http not checking {"waiting":1,"empty":true} []
GOT ALL STICKER PACK

[2023-12-09T14:38:10.777658+00:00] logger-name.WARNING: REQ GET sticker-packs/847199849233514549 failed: Discord\Http\Exceptions\NoPermissionsException: Forbidden - {     "message": "Bots cannot use this endpoint",     "code": 20001 } in D:\Data\DiscordPHP-Http\src\Discord\Http.php:516 Stack trace: #0 D:\Data\DiscordPHP-Http\src\Discord\Http.php(398): Discord\Http\Http->handleError() 
#1 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Internal\FulfilledPromise.php(47): Discord\Http\Http->Discord\Http\{closure}() #2 
D:\Data\DiscordPHP-Http\vendor\react\promise\src\Promise.php(173): React\Promise\Internal\FulfilledPromise->then() #3 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Promise.php(221): React\Promise\Promise::React\Promise\{closure}() #4 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Promise.php(286): React\Promise\Promise->settle() #5 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Deferred.php(45): React\Promise\Promise::React\Promise\{closure}() #6 D:\Data\DiscordPHP-Http\vendor\react\http\src\Io\Transaction.php(90): React\Promise\Deferred->resolve() #7 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Internal\FulfilledPromise.php(47): React\Http\Io\Transaction->React\Http\Io\{closure}() #8 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Promise.php(173): React\Promise\Internal\FulfilledPromise->then() #9 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Promise.php(221): React\Promise\Promise::React\Promise\{closure}() #10 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Promise.php(286): React\Promise\Promise->settle() #11 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Internal\FulfilledPromise.php(47): React\Promise\Promise::React\Promise\{closure}() #12 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Promise.php(180): React\Promise\Internal\FulfilledPromise->then() #13 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Promise.php(221): React\Promise\Promise::React\Promise\{closure}() #14 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Promise.php(286): React\Promise\Promise->settle() #15 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Internal\FulfilledPromise.php(47): React\Promise\Promise::React\Promise\{closure}() #16 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Promise.php(177): React\Promise\Internal\FulfilledPromise->then() #17 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Promise.php(221): React\Promise\Promise::React\Promise\{closure}() #18 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Promise.php(286): React\Promise\Promise->settle() 
#19 D:\Data\DiscordPHP-Http\vendor\react\http\src\Io\Transaction.php(193): React\Promise\Promise::React\Promise\{closure}() #20 D:\Data\DiscordPHP-Http\vendor\evenement\evenement\src\EventEmitterTrait.php(143): React\Http\Io\Transaction->React\Http\Io\{closure}() #21 
D:\Data\DiscordPHP-Http\vendor\react\http\src\Io\ReadableBodyStream.php(50): Evenement\EventEmitter->emit() #22 D:\Data\DiscordPHP-Http\vendor\react\http\src\Io\ReadableBodyStream.php(151): React\Http\Io\ReadableBodyStream->close() #23 D:\Data\DiscordPHP-Http\vendor\react\http\src\Io\ReadableBodyStream.php(33): React\Http\Io\ReadableBodyStream->handleEnd() #24 D:\Data\DiscordPHP-Http\vendor\evenement\evenement\src\EventEmitterTrait.php(143): React\Http\Io\ReadableBodyStream->React\Http\Io\{closure}() #25 D:\Data\DiscordPHP-Http\vendor\react\http\src\Io\CloseProtectionStream.php(96): Evenement\EventEmitter->emit() #26 D:\Data\DiscordPHP-Http\vendor\react\http\src\Io\ClientRequestStream.php(212): React\Http\Io\CloseProtectionStream->handleData() #27 D:\Data\DiscordPHP-Http\vendor\evenement\evenement\src\EventEmitterTrait.php(143): React\Http\Io\ClientRequestStream->handleData() #28 D:\Data\DiscordPHP-Http\vendor\react\stream\src\Util.php(71): Evenement\EventEmitter->emit() #29 D:\Data\DiscordPHP-Http\vendor\evenement\evenement\src\EventEmitterTrait.php(143): React\Stream\Util::React\Stream\{closure}() #30 D:\Data\DiscordPHP-Http\vendor\react\stream\src\DuplexResourceStream.php(196): Evenement\EventEmitter->emit() #31 D:\Data\DiscordPHP-Http\vendor\react\event-loop\src\StreamSelectLoop.php(246): React\Stream\DuplexResourceStream->handleData() #32 D:\Data\DiscordPHP-Http\vendor\react\event-loop\src\StreamSelectLoop.php(213): React\EventLoop\StreamSelectLoop->waitForStreamActivity() #33 D:\Data\DiscordPHP-Http\test.php(38): React\EventLoop\StreamSelectLoop->run() #34 {main} [] []  
[2023-12-09T14:38:10.779149+00:00] logger-name.DEBUG: http not checking {"waiting":0,"empty":true} []
Unhandled promise rejection with Discord\Http\Exceptions\NoPermissionsException: Forbidden - {
    "message": "Bots cannot use this endpoint",
    "code": 20001
} in D:\Data\DiscordPHP-Http\src\Discord\Http.php:516
Stack trace:
#0 D:\Data\DiscordPHP-Http\src\Discord\Http.php(398): Discord\Http\Http->handleError()
#1 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Internal\FulfilledPromise.php(47): Discord\Http\Http->Discord\Http\{closure}()    
#2 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Promise.php(173): React\Promise\Internal\FulfilledPromise->then()
#3 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Promise.php(221): React\Promise\Promise::React\Promise\{closure}()
#4 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Promise.php(286): React\Promise\Promise->settle()
#5 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Deferred.php(45): React\Promise\Promise::React\Promise\{closure}()
#6 D:\Data\DiscordPHP-Http\vendor\react\http\src\Io\Transaction.php(90): React\Promise\Deferred->resolve()
#7 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Internal\FulfilledPromise.php(47): React\Http\Io\Transaction->React\Http\Io\{closure}()
#8 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Promise.php(173): React\Promise\Internal\FulfilledPromise->then()
#9 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Promise.php(221): React\Promise\Promise::React\Promise\{closure}()
#10 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Promise.php(286): React\Promise\Promise->settle()
#11 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Internal\FulfilledPromise.php(47): React\Promise\Promise::React\Promise\{closure}()
#12 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Promise.php(180): React\Promise\Internal\FulfilledPromise->then()
#13 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Promise.php(221): React\Promise\Promise::React\Promise\{closure}()
#14 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Promise.php(286): React\Promise\Promise->settle()
#15 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Internal\FulfilledPromise.php(47): React\Promise\Promise::React\Promise\{closure}()
#16 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Promise.php(177): React\Promise\Internal\FulfilledPromise->then()
#17 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Promise.php(221): React\Promise\Promise::React\Promise\{closure}()
#18 D:\Data\DiscordPHP-Http\vendor\react\promise\src\Promise.php(286): React\Promise\Promise->settle()
#19 D:\Data\DiscordPHP-Http\vendor\react\http\src\Io\Transaction.php(193): React\Promise\Promise::React\Promise\{closure}()
#20 D:\Data\DiscordPHP-Http\vendor\evenement\evenement\src\EventEmitterTrait.php(143): React\Http\Io\Transaction->React\Http\Io\{closure}()
#21 D:\Data\DiscordPHP-Http\vendor\react\http\src\Io\ReadableBodyStream.php(50): Evenement\EventEmitter->emit()
#22 D:\Data\DiscordPHP-Http\vendor\react\http\src\Io\ReadableBodyStream.php(151): React\Http\Io\ReadableBodyStream->close()
#23 D:\Data\DiscordPHP-Http\vendor\react\http\src\Io\ReadableBodyStream.php(33): React\Http\Io\ReadableBodyStream->handleEnd()        
#24 D:\Data\DiscordPHP-Http\vendor\evenement\evenement\src\EventEmitterTrait.php(143): React\Http\Io\ReadableBodyStream->React\Http\Io\{closure}()
#25 D:\Data\DiscordPHP-Http\vendor\react\http\src\Io\CloseProtectionStream.php(96): Evenement\EventEmitter->emit()
#26 D:\Data\DiscordPHP-Http\vendor\react\http\src\Io\ClientRequestStream.php(212): React\Http\Io\CloseProtectionStream->handleData()  
#27 D:\Data\DiscordPHP-Http\vendor\evenement\evenement\src\EventEmitterTrait.php(143): React\Http\Io\ClientRequestStream->handleData()#28 D:\Data\DiscordPHP-Http\vendor\react\stream\src\Util.php(71): Evenement\EventEmitter->emit()
#29 D:\Data\DiscordPHP-Http\vendor\evenement\evenement\src\EventEmitterTrait.php(143): React\Stream\Util::React\Stream\{closure}()    
#30 D:\Data\DiscordPHP-Http\vendor\react\stream\src\DuplexResourceStream.php(196): Evenement\EventEmitter->emit()
#31 D:\Data\DiscordPHP-Http\vendor\react\event-loop\src\StreamSelectLoop.php(246): React\Stream\DuplexResourceStream->handleData()    
#32 D:\Data\DiscordPHP-Http\vendor\react\event-loop\src\StreamSelectLoop.php(213): React\EventLoop\StreamSelectLoop->waitForStreamActivity()
#33 D:\Data\DiscordPHP-Http\test.php(38): React\EventLoop\StreamSelectLoop->run()
#34 {main}
```

![gambar](https://github.com/discord-php/DiscordPHP-Http/assets/87897282/cdc17493-59b8-4054-a6b6-2f8c010bb837)



Real changes will not affect to Bots yet until the DiscordPHP library package is updated to use the provided polyfill class.

If possible, I'd make this separate package and should be only installed for those still doing transition. But I have not find any way yet.

Note: **I personally bump this implementation for v11 DiscordPHP, after releasing v10**