### PR TITLE
Crude implementation to allow Promise V3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^7.4|^8.0",
         "react/http": "^1.2",
         "psr/log": "^1.1 || ^2.0 || ^3.0",
-        "react/promise": "^2.2"
+        "react/promise": "^2.2 || ^3.0.0"
     },
     "suggest": {
         "guzzlehttp/guzzle": "For alternative to ReactPHP/Http Browser"

--- a/src/Discord/Bucket.php
+++ b/src/Discord/Bucket.php
@@ -11,6 +11,7 @@
 
 namespace Discord\Http;
 
+use Composer\InstalledVersions;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use React\EventLoop\LoopInterface;
@@ -88,6 +89,11 @@ class Bucket
     protected $resetTimer;
 
     /**
+     * Whether react/promise v3 is used, if false, using v2
+     */
+    protected $promiseV3 = true;
+
+    /**
      * Bucket constructor.
      *
      * @param string   $name
@@ -100,6 +106,10 @@ class Bucket
         $this->loop = $loop;
         $this->logger = $logger;
         $this->runRequest = $runRequest;
+
+        if (str_starts_with(InstalledVersions::getVersion('react/promise'), '0.3.')) {
+            $this->promiseV3 = true;
+        }
     }
 
     /**
@@ -149,7 +159,8 @@ class Bucket
             /** @var Request */
             $request = $this->queue->dequeue();
 
-            ($this->runRequest)($request)->done(function (ResponseInterface $response) use (&$checkQueue) {
+            // Promises v3 changed `->then` to behave as `->done` and removed `->then`. We still need the behaviour of `->done` in projects using v2
+            ($this->runRequest)($request)->{$this->promiseV3 ? 'then' : 'done'}(function (ResponseInterface $response) use (&$checkQueue) {
                 $resetAfter = (float) $response->getHeaderLine('X-Ratelimit-Reset-After');
                 $limit = $response->getHeaderLine('X-Ratelimit-Limit');
                 $remaining = $response->getHeaderLine('X-Ratelimit-Remaining');

--- a/src/Discord/DriverInterface.php
+++ b/src/Discord/DriverInterface.php
@@ -12,7 +12,7 @@
 namespace Discord\Http;
 
 use Psr\Http\Message\ResponseInterface;
-use React\Promise\ExtendedPromiseInterface;
+use React\Promise\PromiseInterface;
 
 /**
  * Interface for an HTTP driver.
@@ -28,7 +28,7 @@ interface DriverInterface
      *
      * @param Request $request
      *
-     * @return ExtendedPromiseInterface<ResponseInterface>
+     * @return PromiseInterface<ResponseInterface>
      */
-    public function runRequest(Request $request): ExtendedPromiseInterface;
+    public function runRequest(Request $request): PromiseInterface;
 }

--- a/src/Discord/Drivers/Guzzle.php
+++ b/src/Discord/Drivers/Guzzle.php
@@ -17,7 +17,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\RequestOptions;
 use React\EventLoop\LoopInterface;
 use React\Promise\Deferred;
-use React\Promise\ExtendedPromiseInterface;
+use React\Promise\PromiseInterface;
 
 /**
  * guzzlehttp/guzzle driver for Discord HTTP client. (still with React Promise).
@@ -55,7 +55,7 @@ class Guzzle implements DriverInterface
         $this->client = new Client($options);
     }
 
-    public function runRequest(Request $request): ExtendedPromiseInterface
+    public function runRequest(Request $request): PromiseInterface
     {
         // Create a React promise
         $deferred = new Deferred();

--- a/src/Discord/Drivers/React.php
+++ b/src/Discord/Drivers/React.php
@@ -15,7 +15,7 @@ use Discord\Http\DriverInterface;
 use Discord\Http\Request;
 use React\EventLoop\LoopInterface;
 use React\Http\Browser;
-use React\Promise\ExtendedPromiseInterface;
+use React\Promise\PromiseInterface;
 use React\Socket\Connector;
 
 /**
@@ -54,7 +54,7 @@ class React implements DriverInterface
         $this->browser = $browser->withRejectErrorResponse(false);
     }
 
-    public function runRequest(Request $request): ExtendedPromiseInterface
+    public function runRequest(Request $request): PromiseInterface
     {
         return $this->browser->{$request->getMethod()}(
             $request->getUrl(),

--- a/src/Discord/Http.php
+++ b/src/Discord/Http.php
@@ -11,6 +11,7 @@
 
 namespace Discord\Http;
 
+use Composer\InstalledVersions;
 use Discord\Http\Exceptions\BadRequestException;
 use Discord\Http\Exceptions\ContentTooLongException;
 use Discord\Http\Exceptions\InvalidTokenException;
@@ -24,7 +25,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use React\EventLoop\LoopInterface;
 use React\Promise\Deferred;
-use React\Promise\ExtendedPromiseInterface;
+use React\Promise\PromiseInterface;
 use SplQueue;
 
 /**
@@ -127,6 +128,12 @@ class Http
      */
     protected $waiting = 0;
 
+
+    /**
+     * Whether react/promise v3 is used, if false, using v2
+     */
+    protected $promiseV3 = true;
+
     /**
      * Http wrapper constructor.
      *
@@ -141,6 +148,10 @@ class Http
         $this->logger = $logger;
         $this->driver = $driver;
         $this->queue = new SplQueue;
+
+        if (str_starts_with(InstalledVersions::getVersion('react/promise'), '0.3.')) {
+            $this->promiseV3 = true;
+        }
     }
 
     /**
@@ -160,9 +171,9 @@ class Http
      * @param mixed           $content
      * @param array           $headers
      *
-     * @return ExtendedPromiseInterface
+     * @return PromiseInterface
      */
-    public function get($url, $content = null, array $headers = []): ExtendedPromiseInterface
+    public function get($url, $content = null, array $headers = []): PromiseInterface
     {
         if (! ($url instanceof Endpoint)) {
             $url = Endpoint::bind($url);
@@ -178,9 +189,9 @@ class Http
      * @param mixed           $content
      * @param array           $headers
      *
-     * @return ExtendedPromiseInterface
+     * @return PromiseInterface
      */
-    public function post($url, $content = null, array $headers = []): ExtendedPromiseInterface
+    public function post($url, $content = null, array $headers = []): PromiseInterface
     {
         if (! ($url instanceof Endpoint)) {
             $url = Endpoint::bind($url);
@@ -196,9 +207,9 @@ class Http
      * @param mixed           $content
      * @param array           $headers
      *
-     * @return ExtendedPromiseInterface
+     * @return PromiseInterface
      */
-    public function put($url, $content = null, array $headers = []): ExtendedPromiseInterface
+    public function put($url, $content = null, array $headers = []): PromiseInterface
     {
         if (! ($url instanceof Endpoint)) {
             $url = Endpoint::bind($url);
@@ -214,9 +225,9 @@ class Http
      * @param mixed           $content
      * @param array           $headers
      *
-     * @return ExtendedPromiseInterface
+     * @return PromiseInterface
      */
-    public function patch($url, $content = null, array $headers = []): ExtendedPromiseInterface
+    public function patch($url, $content = null, array $headers = []): PromiseInterface
     {
         if (! ($url instanceof Endpoint)) {
             $url = Endpoint::bind($url);
@@ -232,9 +243,9 @@ class Http
      * @param mixed           $content
      * @param array           $headers
      *
-     * @return ExtendedPromiseInterface
+     * @return PromiseInterface
      */
-    public function delete($url, $content = null, array $headers = []): ExtendedPromiseInterface
+    public function delete($url, $content = null, array $headers = []): PromiseInterface
     {
         if (! ($url instanceof Endpoint)) {
             $url = Endpoint::bind($url);
@@ -251,9 +262,9 @@ class Http
      * @param mixed    $content
      * @param array    $headers
      *
-     * @return ExtendedPromiseInterface
+     * @return PromiseInterface
      */
-    public function queueRequest(string $method, Endpoint $url, $content, array $headers = []): ExtendedPromiseInterface
+    public function queueRequest(string $method, Endpoint $url, $content, array $headers = []): PromiseInterface
     {
         $deferred = new Deferred();
 
@@ -318,9 +329,9 @@ class Http
      * @param Request  $request
      * @param Deferred $deferred
      *
-     * @return ExtendedPromiseInterface
+     * @return PromiseInterface
      */
-    protected function executeRequest(Request $request, Deferred $deferred = null): ExtendedPromiseInterface
+    protected function executeRequest(Request $request, Deferred $deferred = null): PromiseInterface
     {
         if ($deferred === null) {
             $deferred = new Deferred();
@@ -332,7 +343,8 @@ class Http
             return $deferred->promise();
         }
 
-        $this->driver->runRequest($request)->done(function (ResponseInterface $response) use ($request, $deferred) {
+        // Promises v3 changed `->then` to behave as `->done` and removed `->then`. We still need the behaviour of `->done` in projects using v2
+        $this->driver->runRequest($request)->{$this->promiseV3 ? 'then' : 'done'}(function (ResponseInterface $response) use ($request, $deferred) {
             $data = json_decode((string) $response->getBody());
             $statusCode = $response->getStatusCode();
 

--- a/src/Discord/RateLimit.php
+++ b/src/Discord/RateLimit.php
@@ -11,12 +11,14 @@
 
 namespace Discord\Http;
 
+use RuntimeException;
+
 /**
  * Represents a rate-limit given by Discord.
  *
  * @author David Cole <david.cole1340@gmail.com>
  */
-class RateLimit
+class RateLimit extends RuntimeException
 {
     /**
      * Whether the rate-limit is global.


### PR DESCRIPTION
This is more of a proof of concept than a full PR.

#26 introduces Promise V3 compatibility with the use of a helper. With an implementation like this, no helper is needed.

DiscordPHP will still be able to use Promise V2 by adding a hard Promise V2 dependency to `composer.json`, and if we include an IDE helper to overwrite the return types in DiscordPHP, nothing will have changed for users of DiscordPHP.

I'd like to hear what you guys think of a solution like this. I want to start using Promise V3, whether that be with #26, this PR, or a v3-compatible fork published on packagist alongside main discordphp-http.